### PR TITLE
Compatibility update

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ LowRankApprox = "0.4"
 PGFPlotsX = "1.2"
 QuadGK = "2.4"
 RecipesBase = "1.0"
-Reexport = "0.2"
+Reexport = ">=0.2"
 StaticArrays = "0.12,1.0"
 julia = "1.5"
 


### PR DESCRIPTION
`Reexport` fixed to `1.0` or higher by `BasisFunctions.jl`, but fixed to versions `0.*` by FrameFun.jl.

Alternatively could change version requirement for `Reexport` to `1.0` here.